### PR TITLE
Update Docker shields at Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ https://github.com/Zimtir/ST-template
 [![code formatting: eslint](https://img.shields.io/badge/code%20linter-eslint-brightgreen?style=flat-square)](https://github.com/eslint/eslint)
 
 ![GitHub Build Action](https://github.com/Zimtir/ST-template/workflows/build%20and%20publish/badge.svg)
-![Docker Image Size (tag)](https://img.shields.io/docker/image-size/9e3u2f0b1/ST-template/latest?logo=Docker)
-![Docker Stars](https://img.shields.io/docker/stars/9e3u2f0b1/ST-template?logo=Docker)
+![Docker Image Size (tag)](https://img.shields.io/docker/image-size/9e3u2f0b1/st-template/latest?logo=Docker)
+![Docker Stars](https://img.shields.io/docker/stars/9e3u2f0b1/st-template?logo=Docker)
 
 ![GitHub package.json dependency version (dev dep on branch)](https://img.shields.io/github/package-json/dependency-version/Zimtir/ST-template/dev/rollup?color=green&logo=Rollup)
 ![GitHub package.json dependency version (dev dep on branch)](https://img.shields.io/github/package-json/dependency-version/Zimtir/ST-template/dev/svelte?color=green)


### PR DESCRIPTION
Changelog:
- Update links to Docker at shields inside Readme

Before:
![image](https://user-images.githubusercontent.com/32175240/87902495-74003d80-ca62-11ea-8dda-076b5628d6a8.png)

After:
![image](https://user-images.githubusercontent.com/32175240/87902486-68ad1200-ca62-11ea-97e0-93b79ca61cd9.png)
